### PR TITLE
compose: move envs to .env; add .env.example; docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Keycloak (dev auth)
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=admin
+
+# Postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=ledger
+
+# API service
+# Internal DNS name 'db' is provided by the compose network
+DATABASE_URL=postgresql://postgres:postgres@db:5432/ledger?sslmode=disable
+DEV_SEED=true
+LOG_FORMAT=json
+LOG_LEVEL=INFO
+
+# JWT / Auth
+# RS256 via JWKS (recommended)
+JWT_JWKS_URL=http://keycloak:8080/realms/internal/protocol/openid-connect/certs
+JWT_JWKS_TTL=300
+# Important: issuer must match the token's `iss`
+# When calling Keycloak via localhost:8082, the token's `iss` is below
+JWT_ISSUER=http://localhost:8082/realms/internal
+JWT_AUDIENCE=ledger-api
+
+# Optional HS256 fallback (leave empty to disable)
+JWT_HS256_SECRET=
+
+# Optional request size limit (bytes)
+# MAX_BODY_BYTES=1048576
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp/
 air.log
 .DS_Store
 *.test
+.env

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ curl -sS -X POST http://localhost:8080/v1/accounts/batch \
 
 ## Local Containers (Compose)
 
+- Copy `.env.example` to `.env` and adjust values as needed.
 - Start: `make compose-up`
 - Logs: `make compose-logs` (shows the dev seed banner with IDs)
 - Stop: `make compose-down`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,8 @@ services:
     container_name: ledger-keycloak
     command: ["start-dev", "--import-realm"]
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
     ports:
       - "8082:8080"
     volumes:
@@ -17,9 +17,9 @@ services:
     image: postgres:16
     container_name: ledger-pg
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: ledger
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-ledger}
     ports:
       - "5432:5432"
     volumes:
@@ -43,17 +43,19 @@ services:
         condition: service_started
     environment:
       # Internal DNS name 'db' from this compose network
-      DATABASE_URL: postgresql://postgres:postgres@db:5432/ledger?sslmode=disable
-      DEV_SEED: "true"
-      LOG_FORMAT: json
-      LOG_LEVEL: INFO
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@db:5432/ledger?sslmode=disable}
+      DEV_SEED: ${DEV_SEED:-true}
+      LOG_FORMAT: ${LOG_FORMAT:-json}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
       # Prefer RS256 via JWKS for service-to-service auth
-      JWT_JWKS_URL: http://keycloak:8080/realms/internal/protocol/openid-connect/certs
+      JWT_JWKS_URL: ${JWT_JWKS_URL:-http://keycloak:8080/realms/internal/protocol/openid-connect/certs}
       # Important: issuer must match the 'iss' in the token returned to Postman
       # Since Postman calls Keycloak via localhost:8082, the token's iss will be http://localhost:8082/realms/internal
       # Ledger only compares strings, so it's fine that this URL isn't reachable inside the container
-      JWT_ISSUER: http://localhost:8082/realms/internal
-      JWT_AUDIENCE: ledger-api
+      JWT_ISSUER: ${JWT_ISSUER:-http://localhost:8082/realms/internal}
+      JWT_AUDIENCE: ${JWT_AUDIENCE:-ledger-api}
+      # Optional HS256 secret; leave empty to disable
+      JWT_HS256_SECRET: ${JWT_HS256_SECRET:-}
     ports:
       - "8080:8080"
     healthcheck:


### PR DESCRIPTION
This PR refactors env handling in compose:

- docker-compose: use  substitution for service envs with sensible defaults
- Add .env.example (copy to .env for local dev)
- Ignore .env in .gitignore to avoid committing secrets
- README: note to copy .env.example before compose

No runtime behavior change aside from reading env values from .env. Dockerfile ENV remains as image defaults, overridden by compose/.env at runtime.