### PR TITLE
Deprecate HS256; no RS256 fallback; docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,10 +308,10 @@ Wiring example (later):
   - `JWT_JWKS_TTL`: cache TTL in seconds (default 300)
   - `JWT_ISSUER`: expected `iss` claim (string compare; ensure it matches exactly)
   - `JWT_AUDIENCE`: expected `aud` claim (string present in array or equals string)
-- HS256 (dev fallback):
-  - `JWT_HS256_SECRET`: shared secret to enable HS256 verification
+- HS256 (deprecated):
+  - `JWT_HS256_SECRET` (DEPRECATED): legacy HS256 verification for development-only scenarios. This will be removed in a future release.
   - `JWT_ISSUER`, `JWT_AUDIENCE` as above
-  - If both JWKS and HS256 are set, JWKS is preferred; HS256 is used as fallback only if RS256 verification fails
+  - When `JWT_JWKS_URL` is configured, HS256 is not used as a fallback anymore.
 
 ## Idempotency (How To Test)
 
@@ -375,10 +375,10 @@ Release planning and pre-v0.1.0 tasks are tracked as GitHub issues.
 
 ## Authentication (Service-to-Service)
 
-- When `JWT_HS256_SECRET` is set, all endpoints require `Authorization: Bearer <jwt>` except:
+- When `JWT_HS256_SECRET` (DEPRECATED) is set, all endpoints require `Authorization: Bearer <jwt>` except:
   - `GET /healthz`, `GET /readyz`, `GET /v1/openapi.yaml`, and `GET /v1/dictionary/*`
 - Token must be HS256 signed; optional claims validated if configured: `iss` (JWT_ISSUER) and `aud` (JWT_AUDIENCE). `exp`/`nbf` respected when present.
-- In dev, omit `JWT_HS256_SECRET` to disable auth while iterating.
+- In dev, prefer RS256 via JWKS. Avoid `JWT_HS256_SECRET` as it is deprecated.
 
 Example (generate a token in Node.js):
 


### PR DESCRIPTION
- Remove automatic HS256 fallback when JWKS is configured
- Log a deprecation warning if JWT_HS256_SECRET is set
- README: mark HS256 deprecated and discourage use; clarify no fallback when JWKS is present
- gofmt run on repo